### PR TITLE
State where to open the linked document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [&lt;made-with-love&gt;](http://rands0n.github.io/made-with-love/)
 
-A web component showing what you did with love
+A web component showing what you did with love.
 
 ## Demo
 
@@ -33,7 +33,7 @@ Or [download as ZIP](https://github.com/rands0n/made-with-love/archive/master.zi
 3.Start using it!
 
 ```html
-<made-with-love name="John Doe" url="http://example.com" color="#F62459"></made-with-love>
+<made-with-love name="John Doe" url="http://example.com" color="#F62459" target="_blank"></made-with-love>
 ```
 
 ## Options
@@ -41,8 +41,9 @@ Or [download as ZIP](https://github.com/rands0n/made-with-love/archive/master.zi
 Attribute | Options       | Default                         | Description
 ---       | ---           | ---                             | ---
 `name`    | *string*      | `Randson`                       | The name of user
-`url`     | *string*      | `https://github.com/rands0n`  | The url of user or organization
+`url`     | *string*      | `https://github.com/rands0n`    | The url of user or organization
 `color`   | *string*      | `#333333`                       | The color of font
+`target`  | *string*      | `_self`                         | Where the linked document should be opened
 
 ## Contributing
 

--- a/made-with-love.html
+++ b/made-with-love.html
@@ -9,20 +9,20 @@ A web component showing what you did with love
 
 ##### Mod example:
 
-    <made-with-love name="Google" url="http://google.com" color="#0099CC"></made-with-love>
+    <made-with-love name="Google" url="http://google.com" color="#0099CC" target="_blank"></made-with-love>
 
 @element made-with-love
 @blurb Element that displays the love.
 @status alpha
 @homepage http://github.com/randsonjs/made-with-love
 -->
-<polymer-element name="made-with-love" attributes="name url color">
+<polymer-element name="made-with-love" attributes="name url color target">
     <template>
 
         <link rel="stylesheet" href="made-with-love.css" />
 
         <div class="with-love" style="color: {{ color }};">
-            Made with <span class="heart">♥</span> by <a href="{{ url }}" style="color: {{ color }};" class="name" target="_blank">{{ name }}</a>
+            Made with <span class="heart">♥</span> by <a href="{{ url }}" style="color: {{ color }};" class="name" target="{{ target }}">{{ name }}</a>
         </div>
 
     </template>
@@ -55,7 +55,16 @@ A web component showing what you did with love
             * @type string
             * @default "#333"
             */
-            color: "#333"
+            color: "#333",
+
+            /**
+            * The `target` attribute allows you to specify where to open the linked document.
+            *
+            * @attribute target
+            * @type string
+            * @default "_self"
+            */
+            target: "_self"
         });
 
     </script>

--- a/made-with-love.html
+++ b/made-with-love.html
@@ -22,7 +22,7 @@ A web component showing what you did with love
         <link rel="stylesheet" href="made-with-love.css" />
 
         <div class="with-love" style="color: {{ color }};">
-            Made with <span class="heart">♥</span> by <a href="{{ url }}" style="color: {{ color }};" class="name">{{ name }}</a>
+            Made with <span class="heart">♥</span> by <a href="{{ url }}" style="color: {{ color }};" class="name" target="_blank">{{ name }}</a>
         </div>
 
     </template>


### PR DESCRIPTION
The current implementation opens the link on `_self` but I have a need to open the link on `_blank` - as per [these values](https://www.w3schools.com/tags/att_a_target.asp).

This PR modifies the Polymer to enable this, whilst still defaulting to `_self` to prevent change of behaviour to any current consumers of the component.